### PR TITLE
Define list items on query parameters

### DIFF
--- a/plugins/actix-web/src/lib.rs
+++ b/plugins/actix-web/src/lib.rs
@@ -169,12 +169,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse,
-                Error = Error,
-                InitError = (),
-            > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.take().map(|a| a.default_service(f));

--- a/plugins/actix-web/src/web.rs
+++ b/plugins/actix-web/src/web.rs
@@ -59,12 +59,12 @@ impl Resource {
 impl<T> HttpServiceFactory for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse,
+        Error = Error,
+        InitError = (),
+    > + 'static,
 {
     fn register(self, config: &mut AppService) {
         self.inner.register(config)
@@ -74,12 +74,12 @@ where
 impl<T> IntoServiceFactory<T> for Resource<actix_web::Resource<T>>
 where
     T: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse,
+        Error = Error,
+        InitError = (),
+    > + 'static,
 {
     fn into_factory(self) -> T {
         self.inner.into_factory()
@@ -242,12 +242,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse,
-                Error = Error,
-                InitError = (),
-            > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.default_service(f);
@@ -302,12 +302,12 @@ impl Scope {
 impl<T> HttpServiceFactory for Scope<actix_web::Scope<T>>
 where
     T: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse,
+        Error = Error,
+        InitError = (),
+    > + 'static,
 {
     fn register(self, config: &mut AppService) {
         if let Some(s) = self.inner {
@@ -382,12 +382,12 @@ where
     where
         F: actix_service::IntoServiceFactory<U>,
         U: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse,
-                Error = Error,
-                InitError = (),
-            > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse,
+            Error = Error,
+            InitError = (),
+        > + 'static,
         U::InitError: Debug,
     {
         self.inner = self.inner.map(|s| s.default_service(f));

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -354,7 +354,7 @@ fn test_params() {
     #[derive(Deserialize, Apiv2Schema)]
     struct BadgeParams {
         res: Option<u16>,
-        color: String,
+        colors: Vec<String>,
     }
 
     #[derive(Deserialize, Apiv2Schema)]
@@ -531,9 +531,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -561,9 +564,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -591,9 +597,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -621,9 +630,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -651,9 +663,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -681,9 +696,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -717,9 +735,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -809,9 +830,12 @@ fn test_params() {
                                     },
                                     {
                                         "in": "query",
-                                        "name": "color",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "name": "colors",
                                         "required": true,
-                                        "type": "string"
+                                        "type": "array"
                                     },
                                     {
                                         "format": "int32",
@@ -2067,12 +2091,12 @@ fn test_multiple_method_routes() {
         F: Fn() -> App<T, B> + Clone + Send + Sync + 'static,
         B: MessageBody + 'static,
         T: ServiceFactory<
-                Config = (),
-                Request = ServiceRequest,
-                Response = ServiceResponse<B>,
-                Error = Error,
-                InitError = (),
-            > + 'static,
+            Config = (),
+            Request = ServiceRequest,
+            Response = ServiceResponse<B>,
+            Error = Error,
+            InitError = (),
+        > + 'static,
     {
         run_and_check_app(f, |addr| {
             let resp = CLIENT
@@ -2552,12 +2576,12 @@ where
     F: Fn() -> App<T, B> + Clone + Send + Sync + 'static,
     B: MessageBody + 'static,
     T: ServiceFactory<
-            Config = (),
-            Request = ServiceRequest,
-            Response = ServiceResponse<B>,
-            Error = Error,
-            InitError = (),
-        > + 'static,
+        Config = (),
+        Request = ServiceRequest,
+        Response = ServiceResponse<B>,
+        Error = Error,
+        InitError = (),
+    > + 'static,
     G: Fn(String) -> U,
 {
     let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
From PR#278
Fixes #239.

For paramters with sequences this change also adds the .items parameter of the ParameterObject and is generated recursively.

In #242 I also tried to correctly document `serde_qs::QsQuery`, but I now don't think it is possible to correctly document `serde_qs` sequences in openapi v2 and am closing that PR.